### PR TITLE
Add standard and ssh example images

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repository provides Dockerfiles for use with Databricks Container Services.
 - [Python2.7](ubuntu/python2.7)
 - [R](ubuntu/R)
 - [DBFS FUSE](ubuntu/dbfsfuse-py3)
+- [SSH](ubuntu/ssh)
 
 ## DockerHub
 The Databricks provided sample images have been published to [DockerHub](https://cloud.docker.com/u/databricksruntime/repository/list)

--- a/README.md
+++ b/README.md
@@ -8,9 +8,12 @@ This repository provides Dockerfiles for use with Databricks Container Services.
 
 ## Images
 
+- [Standard](ubuntu/standard)
 - [Minimal](ubuntu/minimal)
 - [Python](ubuntu/python)
+- [Python2.7](ubuntu/python2.7)
 - [R](ubuntu/R)
+- [DBFS FUSE](ubuntu/dbfsfuse-py3)
 
 ## DockerHub
 The Databricks provided sample images have been published to [DockerHub](https://cloud.docker.com/u/databricksruntime/repository/list)

--- a/ubuntu/dbfsfuse-py3/README.md
+++ b/ubuntu/dbfsfuse-py3/README.md
@@ -1,0 +1,6 @@
+# DBFS FUSE Container
+
+This image shows how to enable the DBFS FUSE mount that mounts DBFS to the local filesystem at `/dbfs`.
+
+Note: In DBR 5.3, we require python2.7 just for starting the FUSE process. This image still configures python3
+for use in notebooks and Spark.

--- a/ubuntu/dbfsfuse-py3/README.md
+++ b/ubuntu/dbfsfuse-py3/README.md
@@ -2,5 +2,6 @@
 
 This image shows how to enable the DBFS FUSE mount that mounts DBFS to the local filesystem at `/dbfs`.
 
-Note: In DBR 5.3, we require python2.7 just for starting the FUSE process. This image still configures python3
-for use in notebooks and Spark.
+Note: In DBR 5.3 and DBR 5.4, we require python2.7 just for starting the FUSE process. This dependency
+will be removed when later DBR versions come out that no longer use the python FUSE client.
+This image still configures python3 for Spark and in notebooks.

--- a/ubuntu/minimal/README.md
+++ b/ubuntu/minimal/README.md
@@ -1,0 +1,19 @@
+Minimal Container
+-----------------
+
+This image is the smallest example of what is necessary to launch a cluster in Databricks.
+This is intended for users who know exactly what they need and do not need.
+
+Supported Features
+------------------
+  - Scala Notebooks
+  - Java/Jar jobs
+
+Unsupported Features
+--------------------
+  - Python Notebooks, Python Jobs
+  - Spark Submit Jobs
+  - %sh
+  - DBFS FUSE mount (/dbfs)
+  - SSH
+  - Ganglia

--- a/ubuntu/minimal/README.md
+++ b/ubuntu/minimal/README.md
@@ -1,16 +1,13 @@
-Minimal Container
-=================
+# Minimal Container
 
 This image is the smallest example of what is necessary to launch a cluster in Databricks.
 This is intended for users who know exactly what they need and do not need.
 
-Supported Features
-------------------
+## Supported Features
   - Scala Notebooks
   - Java/Jar jobs
 
-Unsupported Features
---------------------
+## Unsupported Features
   - Python Notebooks, Python Jobs
   - Spark Submit Jobs
   - %sh

--- a/ubuntu/minimal/README.md
+++ b/ubuntu/minimal/README.md
@@ -1,5 +1,5 @@
 Minimal Container
------------------
+=================
 
 This image is the smallest example of what is necessary to launch a cluster in Databricks.
 This is intended for users who know exactly what they need and do not need.

--- a/ubuntu/ssh/Dockerfile
+++ b/ubuntu/ssh/Dockerfile
@@ -1,9 +1,9 @@
-FROM databricksruntime/dbfsfuse-py3:latest
+FROM databricksruntime/minimal:latest
 
 RUN apt-get update \
-  && apt-get install -y openssh-server \
+  && apt-get install --yes openssh-server \
   && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Warning: the created user has root permissions inside the container
 # Warning: you still need to start the ssh process with `sudo service ssh start`

--- a/ubuntu/ssh/README.md
+++ b/ubuntu/ssh/README.md
@@ -1,0 +1,10 @@
+# SSH Container
+
+This image is an example of how to install and setup SSH for your Docker containers.
+It is as simple as:
+1. Installing `openssh-server`
+1. Adding the ssh user. In this example, we use `ubuntu`, but you can customize this
+1. Launching a cluster with your SSH Public Key
+1. Run `sudo service ssh start` to start the SSH server
+1. On your machine, run `ssh ubuntu@<HOSTNAME> -p 2200 -i <private_key_file_path>`
+

--- a/ubuntu/standard/Dockerfile
+++ b/ubuntu/standard/Dockerfile
@@ -1,0 +1,1 @@
+FROM databricksruntime/dbfsfuse-py3:latest

--- a/ubuntu/standard/Dockerfile
+++ b/ubuntu/standard/Dockerfile
@@ -3,7 +3,7 @@ FROM databricksruntime/dbfsfuse-py3:latest
 RUN apt-get update \
   && apt-get install -y openssh-server \
   && apt-get clean \
-  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Warning: the created user has root permissions inside the container
 # Warning: you still need to start the ssh process with `sudo service ssh start`

--- a/ubuntu/standard/README.md
+++ b/ubuntu/standard/README.md
@@ -10,7 +10,7 @@ Support for features will be added over time.
   - Spark Submit Jobs
   - %sh
   - DBFS FUSE mount (/dbfs)
+  - SSH
 
 ## Unsupported Features
-  - SSH
   - Ganglia

--- a/ubuntu/standard/README.md
+++ b/ubuntu/standard/README.md
@@ -1,11 +1,9 @@
-Standard Container
-==================
+# Standard Container
 
 This image is intended to have feature parity with the current Databricks Runtime.
 Support for features will be added over time.
 
-Supported Features
-------------------
+## Supported Features
   - Scala Notebooks
   - Java/Jar jobs
   - Python Notebooks, Python Jobs
@@ -13,7 +11,6 @@ Supported Features
   - %sh
   - DBFS FUSE mount (/dbfs)
 
-Unsupported Features
---------------------
+## Unsupported Features
   - SSH
   - Ganglia

--- a/ubuntu/standard/README.md
+++ b/ubuntu/standard/README.md
@@ -1,5 +1,5 @@
 Standard Container
------------------
+==================
 
 This image is intended to have feature parity with the current Databricks Runtime.
 Support for features will be added over time.

--- a/ubuntu/standard/README.md
+++ b/ubuntu/standard/README.md
@@ -1,0 +1,19 @@
+Standard Container
+-----------------
+
+This image is intended to have feature parity with the current Databricks Runtime.
+Support for features will be added over time.
+
+Supported Features
+------------------
+  - Scala Notebooks
+  - Java/Jar jobs
+  - Python Notebooks, Python Jobs
+  - Spark Submit Jobs
+  - %sh
+  - DBFS FUSE mount (/dbfs)
+
+Unsupported Features
+--------------------
+  - SSH
+  - Ganglia


### PR DESCRIPTION
This PR adds
- `Standard` image, which is intended to have more feature parity with the current Runtime images.
- `SSH` image, which is an example for how to set up SSH in container services.
- Adds misc. READMEs