### PR TITLE
Set USER env variable in dbfsfuse docker file

### DIFF
--- a/ubuntu/dbfsfuse/Dockerfile
+++ b/ubuntu/dbfsfuse/Dockerfile
@@ -4,3 +4,5 @@ RUN apt-get update \
   && apt-get install -y fuse \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENV USER root

--- a/ubuntu/dbfsfuse/Dockerfile
+++ b/ubuntu/dbfsfuse/Dockerfile
@@ -7,5 +7,5 @@ RUN apt-get update \
 
 # Make sure the USER env variable is set. The files exposed
 # by dbfs-fuse will be owned by this user.
-# Withing the container, the USER is always root.
+# Within the container, the USER is always root.
 ENV USER root

--- a/ubuntu/dbfsfuse/Dockerfile
+++ b/ubuntu/dbfsfuse/Dockerfile
@@ -5,4 +5,7 @@ RUN apt-get update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Make sure the USER env variable is set. The files exposed
+# by dbfs-fuse will be owned by this user.
+# Withing the container, the USER is always root.
 ENV USER root


### PR DESCRIPTION
Make sure the USER env variable is set. The files exposed by dbfs-fuse will be owned by this user.
Within the container, the USER is always root.