### PR TITLE
Create ubuntu18.04-minimal

### DIFF
--- a/experimental/ubuntu/ubuntu18.04-minimal/ubuntu18.04-minimal
+++ b/experimental/ubuntu/ubuntu18.04-minimal/ubuntu18.04-minimal
@@ -8,7 +8,7 @@ RUN apt-get update \
     sudo \
     coreutils \
     procps \
-    strace \
+    strace \ #strace should be installed for users who are trying to set withStrace on their clusters
   && /var/lib/dpkg/info/ca-certificates-java.postinst configure \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/experimental/ubuntu/ubuntu18.04-minimal/ubuntu18.04-minimal
+++ b/experimental/ubuntu/ubuntu18.04-minimal/ubuntu18.04-minimal
@@ -1,0 +1,14 @@
+FROM ubuntu:18.04
+
+RUN apt-get update \
+  && apt-get install --yes \
+    openjdk-8-jdk \
+    iproute2 \
+    bash \
+    sudo \
+    coreutils \
+    procps \
+    strace \
+  && /var/lib/dpkg/info/ca-certificates-java.postinst configure \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Tested with ubuntu18.04Python to be used as the base minimal ubuntu 18.04 for Databricks Runtime 7.1 and 7.2
[env.txt](https://github.com/databricks/containers/files/5199057/env.txt)
 - Example env.txt will need to be included in build replacing the env.yml 
