### PR TITLE
Add explicit traitlets version for DBR <= 7.3 compatibility.

### DIFF
--- a/ubuntu/gpu/pytorch/pytorch.yml
+++ b/ubuntu/gpu/pytorch/pytorch.yml
@@ -12,5 +12,7 @@ dependencies:
 - pytorch::pytorch=1.5.1
 - pytorch::torchvision=0.6.1
 - six=1.14.0  # required by PySpark
+# DBR <= 7.3 are not compatible with traitlets 5.0+
+- traitlets<5.0
 - pip:
   - pyarrow==0.15.1  # rqeuired by PySpark

--- a/ubuntu/gpu/pytorch/pytorch.yml
+++ b/ubuntu/gpu/pytorch/pytorch.yml
@@ -12,7 +12,6 @@ dependencies:
 - pytorch::pytorch=1.5.1
 - pytorch::torchvision=0.6.1
 - six=1.14.0  # required by PySpark
-# DBR <= 7.3 are not compatible with traitlets 5.0+
-- traitlets<5.0
+- traitlets=4.3 # DBR <= 7.3 are not compatible with traitlets 5.0+
 - pip:
   - pyarrow==0.15.1  # rqeuired by PySpark

--- a/ubuntu/gpu/tensorflow/tensorflow.yml
+++ b/ubuntu/gpu/tensorflow/tensorflow.yml
@@ -9,8 +9,7 @@ dependencies:
 - pip=20.0.2
 - python=3.7.6
 - six=1.14.0  # required by PySpark
-# DBR <= 7.3 are not compatible with traitlets 5.0+
-- traitlets<5.0
+- traitlets=4.3 # DBR <= 7.3 are not compatible with traitlets 5.0+
 - pip:
   - pyarrow==0.15.1  # required by PySpark
   - tensorflow-gpu==2.2.0

--- a/ubuntu/gpu/tensorflow/tensorflow.yml
+++ b/ubuntu/gpu/tensorflow/tensorflow.yml
@@ -9,6 +9,8 @@ dependencies:
 - pip=20.0.2
 - python=3.7.6
 - six=1.14.0  # required by PySpark
+# DBR <= 7.3 are not compatible with traitlets 5.0+
+- traitlets<5.0
 - pip:
   - pyarrow==0.15.1  # required by PySpark
   - tensorflow-gpu==2.2.0

--- a/ubuntu/python/env.yml
+++ b/ubuntu/python/env.yml
@@ -10,5 +10,4 @@ dependencies:
   - ipython=7.4.0
   - numpy=1.16.2
   - pandas=0.24.2
-  # DBR <= 7.3 are not compatible with traitlets 5.0+
-  - traitlets<5.0
+  - traitlets=4.3 # DBR <= 7.3 are not compatible with traitlets 5.0+

--- a/ubuntu/python/env.yml
+++ b/ubuntu/python/env.yml
@@ -10,3 +10,5 @@ dependencies:
   - ipython=7.4.0
   - numpy=1.16.2
   - pandas=0.24.2
+  # DBR <= 7.3 are not compatible with traitlets 5.0+
+  - traitlets<5.0


### PR DESCRIPTION
Traitlets 5.0 introduced a breaking change with made it incompatible with our python shell in DBR. Users should use traitlets<5.0 to be compatible with DBR versions <= 7.3.