### PR TITLE
Supporting R on top of databricks standard ubuntu 18 image with few R…

### DIFF
--- a/experimental/ubuntu/standard-with-R/Dockerfile
+++ b/experimental/ubuntu/standard-with-R/Dockerfile
@@ -1,0 +1,27 @@
+FROM databricksruntime/standard:latest
+
+# We are using the more secure long form of pgp key ID of marutter@gmail.com
+# based on these instructions (avoiding firewall issue for some users):
+# https://cran.rstudio.com/bin/linux/ubuntu/#secure-apt
+RUN apt-get update \
+&& DEBIAN_FRONTEND="noninteractive" apt-get install --yes software-properties-common apt-transport-https \
+&& gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 \
+&& gpg -a --export E298A3A825C0D65DFD57CBB651716619E084DAB9 | sudo apt-key add - \
+&& add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran40/' \
+&& apt-get update \
+&& DEBIAN_FRONTEND="noninteractive" apt-get install --yes \
+libssl-dev \
+r-base \
+r-base-dev \
+&& add-apt-repository -r 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran40/' \
+&& apt-key del E298A3A825C0D65DFD57CBB651716619E084DAB9 \
+&& apt-get clean \
+&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# hwriterPlus is used by Databricks to display output in notebook cells
+# Rserve allows Spark to communicate with a local R process to run R code
+# shiny is used by Databricks interpreter
+RUN R -e "install.packages(c('hwriter', 'TeachingDemos', 'htmltools'))"
+RUN R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/hwriterPlus/hwriterPlus_1.0-3.tar.gz', repos=NULL, type='source')"
+RUN R -e "install.packages('Rserve', repos='http://rforge.net/', type='source')"
+RUN R -e "install.packages('shiny', repos='https://cran.rstudio.com/')"

--- a/experimental/ubuntu/standard-with-R/README.md
+++ b/experimental/ubuntu/standard-with-R/README.md
@@ -1,0 +1,7 @@
+# Standard Container with R Runtime support
+
+This image uses the databricksruntime/standard:latest and installs R runtime on top of that. It supports DBR 8.X ()
+
+## Supported Features
+  - Everything supported in [standard image](https://github.com/databricks/containers/tree/master/ubuntu/standard) (Python, Scala, Java, DBFS, SSH, %sh, etc)
+  - R


### PR DESCRIPTION
R fixes mentioned in #54  and supports DBR 8.x

A very common use case for people using databricks is that they want to add libraries and any custom installations at image creation time only so that the cluster start times are reduced. For this they want to start with a base image which contains most of the standard Databricks Runtime stuff. 

Similar was a use case with me but when I tried to get the standard image, it lacked R. And then there were some issues based on DBR 8.X when I tried composing from the existing image. 

Fixes: 
Using the correct cran repo
Using DEBIAN_FRONTEND="noninteractive" mode 
Interpreter REPL not starting issue was fixed by “shiny” package installation

Committing the image hoping it will be useful for others in the same journey. 
