### PR TITLE
[ML-16055] Add a new conda recipe for customers using DCS with DBR 9.0+

### DIFF
--- a/ubuntu/python-conda/Dockerfile
+++ b/ubuntu/python-conda/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install --yes \
     libdigest-sha-perl \
     bzip2
 
-# Download miniconda 4.9.2
+# Download miniconda and use it to install the conda binary
 RUN wget -q https://repo.continuum.io/miniconda/Miniconda3-py38_4.9.2-Linux-x86_64.sh -O miniconda.sh && \
     # Conda must be installed at /databricks/conda
     && /bin/bash miniconda.sh -b -p /databricks/conda \

--- a/ubuntu/python-conda/Dockerfile
+++ b/ubuntu/python-conda/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get update && apt-get install --yes \
     bzip2
 
 # Download miniconda and use it to install the conda binary
-RUN wget -q https://repo.continuum.io/miniconda/Miniconda3-py38_4.9.2-Linux-x86_64.sh -O miniconda.sh && \
+RUN wget -q https://repo.continuum.io/miniconda/Miniconda3-py38_4.9.2-Linux-x86_64.sh -O miniconda.sh \
     # Conda must be installed at /databricks/conda
     && /bin/bash miniconda.sh -b -p /databricks/conda \
-    && rm miniconda.sh \
+    && rm miniconda.sh
 
 FROM databricksruntime/minimal:latest
 

--- a/ubuntu/python-conda/Dockerfile
+++ b/ubuntu/python-conda/Dockerfile
@@ -1,0 +1,33 @@
+FROM ubuntu:18.04 as builder
+
+RUN apt-get update && apt-get install --yes \
+    wget \
+    libdigest-sha-perl \
+    bzip2
+
+# Download miniconda 4.9.2
+RUN wget -q https://repo.continuum.io/miniconda/Miniconda3-py38_4.9.2-Linux-x86_64.sh -O miniconda.sh && \
+    # Conda must be installed at /databricks/conda
+    && /bin/bash miniconda.sh -b -p /databricks/conda \
+    && rm miniconda.sh \
+
+FROM databricksruntime/minimal:latest
+
+COPY --from=builder /databricks/conda /databricks/conda
+
+COPY env.yml /databricks/.conda-env-def/env.yml
+
+RUN /databricks/conda/bin/conda env create --file /databricks/.conda-env-def/env.yml \
+    # Source conda.sh for all login shells.
+    && ln -s /databricks/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh
+
+# Conda recommends using strict channel priority speed up conda operations and reduce package incompatibility problems.
+# Set always_yes to avoid needing -y flags, and improve conda experience in Databricks notebooks.
+RUN /databricks/conda/bin/conda config --system --set channel_priority strict \
+    && /databricks/conda/bin/conda config --system --set always_yes True
+
+# This environment variable must be set to indicate the conda environment to activate.
+# Note that currently, we have to set both of these environment variables. The first one is necessary to indicate that this runtime supports conda.
+# The second one is necessary so that the python notebook/repl can be started (won't work without it)
+ENV DEFAULT_DATABRICKS_ROOT_CONDA_ENV=dcs-minimal
+ENV DATABRICKS_ROOT_CONDA_ENV=dcs-minimal

--- a/ubuntu/python-conda/README.md
+++ b/ubuntu/python-conda/README.md
@@ -1,0 +1,8 @@
+# Conda Python Container
+
+This image is intended as an alternative to the [python](https://github.com/databricks/containers/tree/master/ubuntu/python) docker image. It provides similar functionality but with the latest conda environment.
+
+To use this conda layer with the [databricksruntime/standard](https://github.com/databricks/containers/tree/master/ubuntu/standard) image, replace https://github.com/databricks/containers/blob/master/ubuntu/dbfsfuse/Dockerfile#L1 with `FROM databricksruntime/python-conda:latest` and rebuild all the docker layers.
+
+<!-- TODO: Once the python default image is updated to use virtualenv, update this readme to indicate that it won't support notebook-scoped libraries in runtimes 9.0+. Use the standard image if you wish to do so --!>
+

--- a/ubuntu/python-conda/README.md
+++ b/ubuntu/python-conda/README.md
@@ -1,6 +1,6 @@
 # Conda Python Container
 
-This image is intended as an alternative to the [python](https://github.com/databricks/containers/tree/master/ubuntu/python) docker image. It provides similar functionality but with the latest conda environment.
+This image is an alternative to the [python](https://github.com/databricks/containers/tree/master/ubuntu/python) docker image. It provides similar functionality but with the latest conda environment.
 
 To use this conda layer with the [databricksruntime/standard](https://github.com/databricks/containers/tree/master/ubuntu/standard) image, replace https://github.com/databricks/containers/blob/master/ubuntu/dbfsfuse/Dockerfile#L1 with `FROM databricksruntime/python-conda:latest` and rebuild all the docker layers.
 

--- a/ubuntu/python-conda/README.md
+++ b/ubuntu/python-conda/README.md
@@ -5,7 +5,6 @@ This image is intended as an alternative to the [python](https://github.com/data
 To use this conda layer with the [databricksruntime/standard](https://github.com/databricks/containers/tree/master/ubuntu/standard) image, replace https://github.com/databricks/containers/blob/master/ubuntu/dbfsfuse/Dockerfile#L1 with `FROM databricksruntime/python-conda:latest` and rebuild all the docker layers.
 
 **Important**:
-
 Anaconda Inc. updated their [terms of service](https://www.anaconda.com/terms-of-service) for anaconda.org channels in September 2020. Based on the new terms of service you may require a commercial license if you rely on Anaconda’s packaging and distribution. See [Anaconda Commercial Edition FAQ](https://www.anaconda.com/blog/anaconda-commercial-edition-faq) for more information. Your use of any Anaconda channels is governed by their [terms of service](https://www.anaconda.com/terms-of-service).
 
 <!-- TODO: Once the python default image is updated to use virtualenv, update this readme to indicate that it won't support notebook-scoped libraries in runtimes 9.0+. Use the standard image if you wish to do so --!>

--- a/ubuntu/python-conda/README.md
+++ b/ubuntu/python-conda/README.md
@@ -4,5 +4,9 @@ This image is intended as an alternative to the [python](https://github.com/data
 
 To use this conda layer with the [databricksruntime/standard](https://github.com/databricks/containers/tree/master/ubuntu/standard) image, replace https://github.com/databricks/containers/blob/master/ubuntu/dbfsfuse/Dockerfile#L1 with `FROM databricksruntime/python-conda:latest` and rebuild all the docker layers.
 
+**Important**:
+
+Anaconda Inc. updated their [terms of service](https://www.anaconda.com/terms-of-service) for anaconda.org channels in September 2020. Based on the new terms of service you may require a commercial license if you rely on Anaconda’s packaging and distribution. See [Anaconda Commercial Edition FAQ](https://www.anaconda.com/blog/anaconda-commercial-edition-faq) for more information. Your use of any Anaconda channels is governed by their [terms of service](https://www.anaconda.com/terms-of-service).
+
 <!-- TODO: Once the python default image is updated to use virtualenv, update this readme to indicate that it won't support notebook-scoped libraries in runtimes 9.0+. Use the standard image if you wish to do so --!>
 

--- a/ubuntu/python-conda/env.yml
+++ b/ubuntu/python-conda/env.yml
@@ -1,0 +1,14 @@
+name: dcs-minimal
+channels:
+  - default
+dependencies:
+  # The following package versions mirror those available in DBR 9.0
+  - pip:
+    - pyarrow==4.0.0
+  - python=3.8.8
+  - six=1.15.0
+  - nomkl=3
+  - ipython=7.22.0
+  - numpy=1.20.1
+  - pandas=1.2.4
+  - traitlets=5.0.5

--- a/ubuntu/python-conda/env.yml
+++ b/ubuntu/python-conda/env.yml
@@ -2,13 +2,14 @@ name: dcs-minimal
 channels:
   - default
 dependencies:
-  # The following package versions mirror those available in DBR 9.0
-  - pip:
-    - pyarrow==4.0.0
   - python=3.8.8
+  - pip=20.2.4
   - six=1.15.0
-  - nomkl=3
-  - ipython=7.22.0
-  - numpy=1.20.1
-  - pandas=1.2.4
+  - ipython=7.19.0
+  - nomkl=3.0
+  - numpy=1.19.2
+  - pandas=1.1.5
   - traitlets=5.0.5
+  - wheel=0.35.1
+  - pip:
+    - pyarrow==1.0.1


### PR DESCRIPTION
Add a conda recipe that will be used as an alternative for the python standard recipe (once the standard gets switched to virtualenv). Upgrade the conda and package versions to match the defaults in the latest MLR release.

This recipe will work with all runtimes (both before and after 9.0). However, its primary purpose is for DBR 9.0+, where the standard python DCS recipe will be updated to use virtualenv. This recipe gives customers who require conda an alternative (at the cost of not supporting notebook-scoped libraries from 9.0 onwards)

Tested on https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#setting/clusters/0703-185216-fatal50

Full environment description (with package dependencies) below:

```
name: dcs-minimal
channels:
  - defaults
dependencies:
  - _libgcc_mutex=0.1=main
  - _openmp_mutex=4.5=1_gnu
  - backcall=0.2.0=pyhd3eb1b0_0
  - blas=1.0=openblas
  - ca-certificates=2021.5.25=h06a4308_1
  - certifi=2021.5.30=py38h06a4308_0
  - decorator=5.0.9=pyhd3eb1b0_0
  - ipython=7.19.0=py38hb070fc8_1
  - ipython_genutils=0.2.0=pyhd3eb1b0_1
  - jedi=0.17.0=py38_0
  - ld_impl_linux-64=2.35.1=h7274673_9
  - libffi=3.3=he6710b0_2
  - libgcc-ng=9.3.0=h5101ec6_17
  - libgfortran-ng=7.5.0=ha8ba4b0_17
  - libgfortran4=7.5.0=ha8ba4b0_17
  - libgomp=9.3.0=h5101ec6_17
  - libopenblas=0.3.13=h4367d64_0
  - libstdcxx-ng=9.3.0=hd4cf53a_17
  - ncurses=6.2=he6710b0_1
  - nomkl=3.0=0
  - numpy=1.19.2=py38h6163131_0
  - numpy-base=1.19.2=py38h75fe3a5_0
  - openssl=1.1.1k=h27cfd23_0
  - pandas=1.1.5=py38ha9443f7_0
  - parso=0.8.2=pyhd3eb1b0_0
  - pexpect=4.8.0=pyhd3eb1b0_3
  - pickleshare=0.7.5=pyhd3eb1b0_1003
  - pip=20.2.4=py38h06a4308_0
  - prompt-toolkit=3.0.17=pyh06a4308_0
  - ptyprocess=0.7.0=pyhd3eb1b0_2
  - pygments=2.9.0=pyhd3eb1b0_0
  - python=3.8.8=hdb3f193_5
  - python-dateutil=2.8.1=pyhd3eb1b0_0
  - pytz=2021.1=pyhd3eb1b0_0
  - readline=8.1=h27cfd23_0
  - setuptools=52.0.0=py38h06a4308_0
  - six=1.15.0=py38h06a4308_0
  - sqlite=3.36.0=hc218d9a_0
  - tk=8.6.10=hbc83047_0
  - traitlets=5.0.5=pyhd3eb1b0_0
  - wcwidth=0.2.5=py_0
  - wheel=0.35.1=pyhd3eb1b0_0
  - xz=5.2.5=h7b6447c_0
  - zlib=1.2.11=h7b6447c_3
  - pip:
    - pyarrow==1.0.1
prefix: /databricks/conda/envs/dcs-minimal
```