### PR TITLE
increase version of IPython to 7.19.0 for Notebooks

### DIFF
--- a/ubuntu/python/Dockerfile
+++ b/ubuntu/python/Dockerfile
@@ -17,7 +17,7 @@ RUN virtualenv -p python3.8 --system-site-packages /databricks/python3
 RUN /databricks/python3/bin/pip install \
   six==1.15.0 \
   # downgrade ipython to maintain backwards compatibility with 7.x and 8.x runtimes
-  ipython==7.4.0 \
+  ipython==7.19.0 \
   numpy==1.19.2 \
   pandas==1.2.4 \
   pyarrow==4.0.0 \

--- a/ubuntu/python/Dockerfile
+++ b/ubuntu/python/Dockerfile
@@ -16,7 +16,7 @@ RUN virtualenv -p python3.8 --system-site-packages /databricks/python3
 # Versions are intended to reflect DBR 9.0
 RUN /databricks/python3/bin/pip install \
   six==1.15.0 \
-  # downgrade ipython to maintain backwards compatibility with 7.x and 8.x runtimes
+  # ensure minimum ipython version for Python autocomplete with jedi 0.17.x
   ipython==7.19.0 \
   numpy==1.19.2 \
   pandas==1.2.4 \


### PR DESCRIPTION
IPython 7.19.0 is required for notebooks to work with Python autocomplete in the base Docker image for:
* databricksruntime/standard:8.x
* databricksruntime/standard:9.x
* databricksruntime/python:8.x
* databricksruntime/python:9.x
