### PR TITLE
Add compatibility warning to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 **NOTE:** The `latest` tags have been removed on most images in favor of runtime-specific tags, with the exception being the `databricksruntime/standard` image. If your build relied on an image tagged with `latest`, please update it to match the runtime version of the cluster.
 
+**NOTE:** The `latest` tags have been removed on most images in favor of runtime-specific tags, with the exception being the `databricksruntime/standard` image. If your build relied on an image tagged with `latest`, please update it to match the runtime version of the cluster.
+
 This repository provides Dockerfiles for use with Databricks Container Services. These Dockerfiles are meant as a reference and a starting point, enabling users to build their own custom images to suit thier specific needs.
+
+## Warning: Runtime Incompatability
+
+The Dockerfiles on the master branch are currently not maintained to be backwards compatible with every Databricks Runtime version, and are not always updated for new versions. The only guarantee of compatability is for images on [DockerHub](https://hub.docker.com/u/databricksruntime) that are tagged for specific runtime versions.
 
 ### Documentation
 - [Azure](https://docs.azuredatabricks.net/user-guide/clusters/custom-containers.html)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository provides Dockerfiles for use with Databricks Container Services.
 
 ## Warning: Runtime Incompatibility
 
-The Dockerfiles on the master branch are currently not maintained to be backwards compatible with every Databricks Runtime version, and are not always updated for new versions. The only guarantee of compatibility is for images on [DockerHub](https://hub.docker.com/u/databricksruntime) that are tagged for specific runtime versions.
+The Dockerfiles on the master branch are currently not maintained to be backwards compatible with every Databricks Runtime version, and are not always updated for new versions.
 
 ## Documentation
 - [Azure](https://docs.azuredatabricks.net/user-guide/clusters/custom-containers.html)

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 This repository provides Dockerfiles for use with Databricks Container Services. These Dockerfiles are meant as a reference and a starting point, enabling users to build their own custom images to suit thier specific needs.
 
-## Warning: Runtime Incompatability
+## Warning: Runtime Incompatibility
 
-The Dockerfiles on the master branch are currently not maintained to be backwards compatible with every Databricks Runtime version, and are not always updated for new versions. The only guarantee of compatability is for images on [DockerHub](https://hub.docker.com/u/databricksruntime) that are tagged for specific runtime versions.
+The Dockerfiles on the master branch are currently not maintained to be backwards compatible with every Databricks Runtime version, and are not always updated for new versions. The only guarantee of compatibility is for images on [DockerHub](https://hub.docker.com/u/databricksruntime) that are tagged for specific runtime versions.
 
 ### Documentation
 - [Azure](https://docs.azuredatabricks.net/user-guide/clusters/custom-containers.html)

--- a/README.md
+++ b/README.md
@@ -2,15 +2,13 @@
 
 **NOTE:** The `latest` tags have been removed on most images in favor of runtime-specific tags, with the exception being the `databricksruntime/standard` image. If your build relied on an image tagged with `latest`, please update it to match the runtime version of the cluster.
 
-**NOTE:** The `latest` tags have been removed on most images in favor of runtime-specific tags, with the exception being the `databricksruntime/standard` image. If your build relied on an image tagged with `latest`, please update it to match the runtime version of the cluster.
-
 This repository provides Dockerfiles for use with Databricks Container Services. These Dockerfiles are meant as a reference and a starting point, enabling users to build their own custom images to suit thier specific needs.
 
 ## Warning: Runtime Incompatibility
 
 The Dockerfiles on the master branch are currently not maintained to be backwards compatible with every Databricks Runtime version, and are not always updated for new versions. The only guarantee of compatibility is for images on [DockerHub](https://hub.docker.com/u/databricksruntime) that are tagged for specific runtime versions.
 
-### Documentation
+## Documentation
 - [Azure](https://docs.azuredatabricks.net/user-guide/clusters/custom-containers.html)
 - [AWS](https://docs.databricks.com/user-guide/clusters/custom-containers.html)
 


### PR DESCRIPTION
We haven't kept the Dockerfiles updated for every runtime version and we haven't ensured that updates are backwards compatible. Let's add a warning here so users are aware.