### PR TITLE
Add DCS images that are compatible with DBR 10.4

### DIFF
--- a/ubuntu/R/Dockerfile
+++ b/ubuntu/R/Dockerfile
@@ -1,4 +1,4 @@
-FROM databricksruntime/minimal:9.x
+FROM databricksruntime/minimal:10.4
 
 # Suppress interactive configuration prompts
 ENV DEBIAN_FRONTEND=noninteractive

--- a/ubuntu/R/README.md
+++ b/ubuntu/R/README.md
@@ -1,6 +1,6 @@
 # R container
 
-**Disclaimer** This image is not regularly patched for security updates. It is the user's responsibility to regularly patch and rebuild the images. If concerned, you can always opt to build the containers using your own Dockerfile.
+**Disclaimer** This image is not regularly patched for security updates. It is the user's responsibility to regularly patch and rebuild the images. If this is a concern, please set automation to regularly rebuild your DCS base images
 
 This image shows how to setup R and RStudio Server. 
 

--- a/ubuntu/R/README.md
+++ b/ubuntu/R/README.md
@@ -1,5 +1,7 @@
 # R container
 
+**Disclaimer** This image is not regularly patched for security updates. It is the user's responsibility to regularly patch and rebuild the images. If concerned, you can always opt to build the containers using your own Dockerfile.
+
 This image shows how to setup R and RStudio Server. 
 
 Note that you will still need to use a databricks init script to start the RStudio

--- a/ubuntu/dbfsfuse/Dockerfile
+++ b/ubuntu/dbfsfuse/Dockerfile
@@ -1,4 +1,4 @@
-FROM databricksruntime/python:9.x
+FROM databricksruntime/python:10.4
 
 RUN apt-get update \
   && apt-get install -y fuse \

--- a/ubuntu/dbfsfuse/README.md
+++ b/ubuntu/dbfsfuse/README.md
@@ -2,6 +2,8 @@
 
 This image shows how to enable the DBFS FUSE mount that mounts DBFS to the local filesystem at `/dbfs`.
 
+**Disclaimer** This image is not regularly patched for security updates. It is the user's responsibility to regularly patch and rebuild the images. If concerned, you can always opt to build the containers using your own Dockerfile.
+
 Note: In DBR 5.3, DBR 5.4, and DBR 5.5, we require python2.7 just for starting the FUSE process. This dependency
 will be removed when later DBR versions come out that no longer use the python FUSE client.
 This image still configures python3 for Spark and in notebooks.

--- a/ubuntu/dbfsfuse/README.md
+++ b/ubuntu/dbfsfuse/README.md
@@ -2,7 +2,7 @@
 
 This image shows how to enable the DBFS FUSE mount that mounts DBFS to the local filesystem at `/dbfs`.
 
-**Disclaimer** This image is not regularly patched for security updates. It is the user's responsibility to regularly patch and rebuild the images. If concerned, you can always opt to build the containers using your own Dockerfile.
+**Disclaimer** This image is not regularly patched for security updates. It is the user's responsibility to regularly patch and rebuild the images. If this is a concern, please set automation to regularly rebuild your DCS base images
 
 Note: In DBR 5.3, DBR 5.4, and DBR 5.5, we require python2.7 just for starting the FUSE process. This dependency
 will be removed when later DBR versions come out that no longer use the python FUSE client.

--- a/ubuntu/minimal/Dockerfile
+++ b/ubuntu/minimal/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update \
   && apt-get install --yes \

--- a/ubuntu/minimal/README.md
+++ b/ubuntu/minimal/README.md
@@ -1,5 +1,7 @@
 # Minimal Container
 
+**Disclaimer** This image is not regularly patched for security updates. It is the user's responsibility to regularly patch and rebuild the images. If concerned, you can always opt to build the containers using your own Dockerfile.
+
 **Note:** This image specifically for Databricks Runtime 7.x and above; see the [latest runtime releases](https://docs.databricks.com/release-notes/runtime/releases.html#databricks-runtime-releases) for reference. 
 
 This image is the smallest example of what is necessary to launch a cluster in Databricks.

--- a/ubuntu/minimal/README.md
+++ b/ubuntu/minimal/README.md
@@ -1,6 +1,6 @@
 # Minimal Container
 
-**Disclaimer** This image is not regularly patched for security updates. It is the user's responsibility to regularly patch and rebuild the images. If concerned, you can always opt to build the containers using your own Dockerfile.
+**Disclaimer** This image is not regularly patched for security updates. It is the user's responsibility to regularly patch and rebuild the images. If this is a concern, please set automation to regularly rebuild your DCS base images
 
 **Note:** This image specifically for Databricks Runtime 7.x and above; see the [latest runtime releases](https://docs.databricks.com/release-notes/runtime/releases.html#databricks-runtime-releases) for reference. 
 

--- a/ubuntu/python/Dockerfile
+++ b/ubuntu/python/Dockerfile
@@ -1,4 +1,4 @@
-FROM databricksruntime/minimal:9.x
+FROM databricksruntime/minimal:10.4
 
 # Installs python 3.8 and virtualenv for Spark and Notebooks
 RUN apt-get update \

--- a/ubuntu/python/README.md
+++ b/ubuntu/python/README.md
@@ -1,5 +1,7 @@
 # Python Container
 
+**Disclaimer** This image is not regularly patched for security updates. It is the user's responsibility to regularly patch and rebuild the images. If concerned, you can always opt to build the containers using your own Dockerfile.
+
 This image adds a working Python environment to `databricksruntime/minimal` using virtualenv, and is supported for Databricks Runtime 7.3 LTS and above.
 For a conda-based Python environment, an alternative image can be found [here](https://github.com/databricks/containers/tree/master/ubuntu/python-conda).
 Note that Databricks recommends using this recipe unless you need libraries that are only available from conda, as certain features like notebook-scoped libraries (e.g. `%pip`) will not work with the conda recipe in newer runtimes (Databricks Runtime 9.0 and above).

--- a/ubuntu/python/README.md
+++ b/ubuntu/python/README.md
@@ -1,6 +1,6 @@
 # Python Container
 
-**Disclaimer** This image is not regularly patched for security updates. It is the user's responsibility to regularly patch and rebuild the images. If concerned, you can always opt to build the containers using your own Dockerfile.
+**Disclaimer** This image is not regularly patched for security updates. It is the user's responsibility to regularly patch and rebuild the images. If this is a concern, please set automation to regularly rebuild your DCS base images
 
 This image adds a working Python environment to `databricksruntime/minimal` using virtualenv, and is supported for Databricks Runtime 7.3 LTS and above.
 For a conda-based Python environment, an alternative image can be found [here](https://github.com/databricks/containers/tree/master/ubuntu/python-conda).

--- a/ubuntu/ssh/Dockerfile
+++ b/ubuntu/ssh/Dockerfile
@@ -1,4 +1,4 @@
-FROM databricksruntime/minimal:9.x
+FROM databricksruntime/minimal:10.4
 
 RUN apt-get update \
   && apt-get install --yes openssh-server \

--- a/ubuntu/ssh/README.md
+++ b/ubuntu/ssh/README.md
@@ -1,5 +1,7 @@
 # SSH Container
 
+**Disclaimer** This image is not regularly patched for security updates. It is the user's responsibility to regularly patch and rebuild the images. If concerned, you can always opt to build the containers using your own Dockerfile.
+
 This image is an example of how to install and setup SSH for your Docker containers.
 It is as simple as:
 1. Installing `openssh-server`

--- a/ubuntu/ssh/README.md
+++ b/ubuntu/ssh/README.md
@@ -1,6 +1,6 @@
 # SSH Container
 
-**Disclaimer** This image is not regularly patched for security updates. It is the user's responsibility to regularly patch and rebuild the images. If concerned, you can always opt to build the containers using your own Dockerfile.
+**Disclaimer** This image is not regularly patched for security updates. It is the user's responsibility to regularly patch and rebuild the images. If this is a concern, please set automation to regularly rebuild your DCS base images
 
 This image is an example of how to install and setup SSH for your Docker containers.
 It is as simple as:

--- a/ubuntu/standard/Dockerfile
+++ b/ubuntu/standard/Dockerfile
@@ -1,4 +1,4 @@
-FROM databricksruntime/dbfsfuse:9.x
+FROM databricksruntime/dbfsfuse:10.4
 
 RUN apt-get update \
   && apt-get install -y openssh-server \

--- a/ubuntu/standard/README.md
+++ b/ubuntu/standard/README.md
@@ -1,5 +1,7 @@
 # Standard Container
 
+**Disclaimer** This image is not regularly patched for security updates. It is the user's responsibility to regularly patch and rebuild the images. If concerned, you can always opt to build the containers using your own Dockerfile.
+
 This image is intended to have feature parity with the current Databricks Runtime.
 Support for features will be added over time.
 

--- a/ubuntu/standard/README.md
+++ b/ubuntu/standard/README.md
@@ -1,6 +1,6 @@
 # Standard Container
 
-**Disclaimer** This image is not regularly patched for security updates. It is the user's responsibility to regularly patch and rebuild the images. If concerned, you can always opt to build the containers using your own Dockerfile.
+**Disclaimer** This image is not regularly patched for security updates. It is the user's responsibility to regularly patch and rebuild the images. If this is a concern, please set automation to regularly rebuild your DCS base images
 
 This image is intended to have feature parity with the current Databricks Runtime.
 Support for features will be added over time.


### PR DESCRIPTION
This patch changes the dockerfile to be built compatibly with DBR 10.4, specifically the the linux version is upgraded to 20.04

Smoke tests were performed to verify that the following cases are supported:
* a basic spark command can work in scala
* a basic spark command can work in python
* a basic sql query works
* notebook-scoped python libraries can be installed with pip
* dbfs fuse works