### PR TITLE
Update rbase for ubuntu 20

### DIFF
--- a/ubuntu/R/Dockerfile
+++ b/ubuntu/R/Dockerfile
@@ -11,21 +11,22 @@ RUN apt-get update \
   && apt-get install --yes software-properties-common apt-transport-https \
   && gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 \
   && gpg -a --export E298A3A825C0D65DFD57CBB651716619E084DAB9 | sudo apt-key add - \
-  && add-apt-repository -y 'deb [arch=amd64,i386] https://cran.rstudio.com/bin/linux/ubuntu bionic-cran40/' \
+  && add-apt-repository -y "deb [arch=amd64,i386] https://cran.rstudio.com/bin/linux/ubuntu $(lsb_release -cs)-cran40/" \
   && apt-get update \
   && apt-get install --yes \
     libssl-dev \
     r-base \
     r-base-dev \
-  && add-apt-repository -r 'deb [arch=amd64,i386] https://cran.rstudio.com/bin/linux/ubuntu bionic-cran40/' \
+  && add-apt-repository -r "deb [arch=amd64,i386] https://cran.rstudio.com/bin/linux/ubuntu $(lsb_release -cs)-cran40/" \
   && apt-key del E298A3A825C0D65DFD57CBB651716619E084DAB9 \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # hwriterPlus is used by Databricks to display output in notebook cells
+# hwriterPlus is removed for newer version of R, so we hardcode the dependency to archived version
 # Rserve allows Spark to communicate with a local R process to run R code
-RUN R -e "options(repos = list(MRAN = 'https://mran.microsoft.com/snapshot/2018-08-01', CRAN = 'https://cran.microsoft.com/')); install.packages(c('hwriterPlus'))" \
- && R -e "options(repos = list(MRAN = 'https://mran.microsoft.com/snapshot/2018-08-01', CRAN = 'https://cran.microsoft.com/')); install.packages(c('htmltools'))" \
+RUN R -e "options(repos = list(MRAN = 'https://mran.microsoft.com/snapshot/2022-04-08', CRAN = 'https://cran.microsoft.com/')); install.packages(c('hwriter', 'TeachingDemos', 'htmltools'))" \
+ && R -e "install.packages('https://cran.r-project.org/src/contrib/Archive/hwriterPlus/hwriterPlus_1.0-3.tar.gz', repos=NULL, type='source')" \
  && R -e "install.packages('Rserve', repos='http://rforge.net/')"
 
 # Additional instructions to setup rstudio. If you dont need rstudio, you can 
@@ -44,5 +45,6 @@ RUN apt-get update \
  # Download rstudio 1.4 package for ubuntu 18.04 and install it.
  && apt-get install -y wget \
  && apt-get install -y gdebi-core \
- && wget https://download2.rstudio.org/server/bionic/amd64/rstudio-server-1.4.1106-amd64.deb \
- && gdebi -n rstudio-server-1.4.1106-amd64.deb && rstudio-server version
+ && wget https://download2.rstudio.org/server/bionic/amd64/rstudio-server-2022.02.1-461-amd64.deb \
+ && gdebi -n rstudio-server-2022.02.1-461-amd64.deb && rstudio-server version
+


### PR DESCRIPTION
Updates rbase to be compatible with ubuntu 20 (focal)
* removed the hardcoded ubuntu name when adding repo
* hardcode hwriterPlus dependency since it's removed in newer versions of R
* install latest version of RStudio