### PR TITLE
[PROD-28567] Install virtualenv for R image

### DIFF
--- a/ubuntu/R/Dockerfile
+++ b/ubuntu/R/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
   && apt-get install -y \
     python3.8 \
-    virtualenv \
+    virtualenv
 
 # We add RStudio's debian source to install the latest r-base version (4.1)
 # We are using the more secure long form of pgp key ID of marutter@gmail.com

--- a/ubuntu/R/Dockerfile
+++ b/ubuntu/R/Dockerfile
@@ -3,7 +3,7 @@ FROM databricksruntime/minimal:10.4-LTS
 # Suppress interactive configuration prompts
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Installs python 3.8 and virtualenv for Spark and Notebooks
+# Install python 3.8 and virtualenv for Spark and Notebooks
 RUN apt-get update \
   && apt-get install -y \
     python3.8 \

--- a/ubuntu/R/Dockerfile
+++ b/ubuntu/R/Dockerfile
@@ -3,6 +3,12 @@ FROM databricksruntime/minimal:10.4-LTS
 # Suppress interactive configuration prompts
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Installs python 3.8 and virtualenv for Spark and Notebooks
+RUN apt-get update \
+  && apt-get install -y \
+    python3.8 \
+    virtualenv \
+
 # We add RStudio's debian source to install the latest r-base version (4.1)
 # We are using the more secure long form of pgp key ID of marutter@gmail.com
 # based on these instructions (avoiding firewall issue for some users):
@@ -38,8 +44,6 @@ COPY Rprofile.site /usr/lib/R/etc/Rprofile.site
 
 # Rstudio installation.
 RUN apt-get update \
- # Installation of rstudio in databricks needs /usr/bin/python.
- && apt-get install -y python \
  # Install gdebi-core.
  && apt-get install -y gdebi-core \
  # Download rstudio 1.4 package for ubuntu 18.04 and install it.
@@ -48,3 +52,5 @@ RUN apt-get update \
  && wget https://download2.rstudio.org/server/bionic/amd64/rstudio-server-2022.02.1-461-amd64.deb \
  && gdebi -n rstudio-server-2022.02.1-461-amd64.deb && rstudio-server version
 
+# Initialize the default environment that Spark and notebooks will use
+RUN virtualenv -p python3.8 --system-site-packages /databricks/python3


### PR DESCRIPTION
Need to install `virtualenv` for all docker images to make them work with DBR 11+.  Check [PROD-28567] for more details.

Manually built a [docker image](https://hub.docker.com/layers/205077020/msharifdb/milads-test/latest/images/sha256-03e2ff0eb30440285afd696ae64c17eefc10527927d9ae30d15218d5b1dab0e9?context=repo) `msharifdb/milads-test:latest` and created a cluster with the docker image on [E2 dogfood](https://e2-dogfood.staging.cloud.databricks.com/?o=6051921418418893#setting/clusters/0426-234449-x0yfx8sy/configuration) and ran some R commands in a notebook.