### PR TITLE
update python-pip to python3

### DIFF
--- a/experimental/ubuntu/ganglia/Dockerfile
+++ b/experimental/ubuntu/ganglia/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -q -y --force-yes --fix-missing --ignore-m
         ganglia-monitor \
         ganglia-webfrontend \
         ganglia-monitor-python \
-        python-pip \
+        python3-pip \
         rsync \
         cron \
     && apt-get clean \


### PR DESCRIPTION
@evanye , could you review this? It's a change to remove an unneeded binary and an update to use python3-pip instead of python-pip. 