### PR TITLE
add seaborn package to databricksruntime/python

### DIFF
--- a/ubuntu/python/Dockerfile
+++ b/ubuntu/python/Dockerfile
@@ -23,7 +23,8 @@ RUN /databricks/python3/bin/pip install \
   pandas==1.2.4 \
   pyarrow==4.0.0 \
   matplotlib==3.4.2 \
-  jinja2==2.11.3
+  jinja2==2.11.3 \
+  seaborn==0.11.1
 
 # Specifies where Spark will look for the python process
 ENV PYSPARK_PYTHON=/databricks/python3/bin/python3


### PR DESCRIPTION
Databricks notebooks attached to clusters using the provided databricks runtime version 10.4-LTS are able to import and use `seaborn`. 

When building a custom docker image built from `databricksruntime/standard:10.4-LTS` (which builds on databricksruntime/python), it was discovered that notebooks that imported seaborn were not able to run because the package was missing from the container.

This pull requests adds the missing `seaborn` package to the `databricksruntime/python`. The specified version is the same version that the provided databricks runtime version 10.4-LTS uses, found by running `pip show seaborn` on a cluster using databricks runtime version 10.4-LTS