### PR TITLE
Create DCS image to enable Files in Repos for DBR 9.1

### DIFF
--- a/experimental/ubuntu/files-in-repos/Dockerfile
+++ b/experimental/ubuntu/files-in-repos/Dockerfile
@@ -1,0 +1,4 @@
+FROM databricksruntime/standard:10.4-LTS
+
+RUN mkdir -p /databricks/spark/scripts/fuse \
+  && touch /databricks/spark/scripts/fuse/start_files_in_repos_daemon

--- a/experimental/ubuntu/files-in-repos/Dockerfile
+++ b/experimental/ubuntu/files-in-repos/Dockerfile
@@ -1,4 +1,4 @@
-FROM databricksruntime/standard:10.4-LTS
+FROM databricksruntime/standard:9.1-LTS
 
 RUN mkdir -p /databricks/spark/scripts/fuse \
   && touch /databricks/spark/scripts/fuse/start_files_in_repos_daemon

--- a/experimental/ubuntu/files-in-repos/README.md
+++ b/experimental/ubuntu/files-in-repos/README.md
@@ -1,3 +1,5 @@
 # Files in Repos Container
 
 This image shows how to enable the Files in Repos FUSE mount that mounts to the local filesystem at `/Workspace`.
+
+For DBR 11 LTS and above, the Files in Repos FUSE mount will be created for the standard DCS image.

--- a/experimental/ubuntu/files-in-repos/README.md
+++ b/experimental/ubuntu/files-in-repos/README.md
@@ -1,0 +1,3 @@
+# Files in Repos Container
+
+This image shows how to enable the Files in Repos FUSE mount that mounts to the local filesystem at `/Workspace`.

--- a/experimental/ubuntu/files-in-repos/README.md
+++ b/experimental/ubuntu/files-in-repos/README.md
@@ -2,4 +2,4 @@
 
 This image shows how to enable the Files in Repos FUSE mount that mounts to the local filesystem at `/Workspace`.
 
-For DBR 11 LTS and above, the Files in Repos FUSE mount will be created for the standard DCS image.
+For DBR 11 LTS and above, the Files in Repos FUSE mount will always be created, so this custom image will no longer be needed and the standard DCS image may be used instead.


### PR DESCRIPTION
For DBR 11 LTS and above, Files in Repos will work with the standard DCS image.

For DBR 9.1 LTS, we provide this custom DCS image to start the Files in Repos FUSE daemon.