### PR TITLE
Update minimal container README for DBR 11.x

### DIFF
--- a/ubuntu/minimal/README.md
+++ b/ubuntu/minimal/README.md
@@ -5,6 +5,8 @@
 This image is the smallest example of what is necessary to launch a cluster in Databricks.
 This is intended for users who know exactly what they need and do not need.
 
+Please set the `spark.databricks.driverNfs.enabled false` Spark config when creating a cluster with this image for Databricks Runtime 11.x or higher.
+
 ## Supported Features
   - Scala Notebooks
   - Java/Jar jobs


### PR DESCRIPTION
This change adds a note in the README for adding the `spark.databricks.driverNfs.enabled false` Spark config while using this image with Databricks Runtime 11.x or higher.  This provides a workaround if the cluster startup fails because of the unavailability of `virtualenv` in the image.