### PR TITLE
Update R image description to use required Spark conf

### DIFF
--- a/ubuntu/R/README.md
+++ b/ubuntu/R/README.md
@@ -14,3 +14,5 @@ if [[ ! -f "$RSTUDIO_BIN" && $DB_IS_DRIVER = "TRUE" ]]; then
   rstudio-server restart || true
 fi
 ```
+
+Please set the `spark.databricks.driverNfs.enabled false` Spark config when creating a cluster with this image for Databricks Runtime 11.x or higher.


### PR DESCRIPTION
See similar change made for the `minimal` image for context https://github.com/databricks/containers/pull/113

This change adds a note in the README for adding the spark.databricks.driverNfs.enabled false Spark config while using this image with Databricks Runtime 11.x or higher. This provides a workaround if the cluster startup fails because of the unavailability of virtualenv in the image.