### PR TITLE
Add libraries user

### DIFF
--- a/ubuntu/minimal/Dockerfile
+++ b/ubuntu/minimal/Dockerfile
@@ -12,3 +12,7 @@ RUN apt-get update \
   && /var/lib/dpkg/info/ca-certificates-java.postinst configure \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Add new user for cluster library installation
+RUN useradd libraries \
+  && usermod -L libraries


### PR DESCRIPTION
This PR adds a new `libraries` user for use when installing cluster libraries.