### PR TITLE
Install acl package

### DIFF
--- a/ubuntu/minimal/Dockerfile
+++ b/ubuntu/minimal/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
     sudo \
     coreutils \
     procps \
+    acl \
   && /var/lib/dpkg/info/ca-certificates-java.postinst configure \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
This PR installs the `acl` package in the minimal image to allow manipulating file ACLs.