### PR TITLE
Purge the pip cache after installing torch

### DIFF
--- a/ubuntu/gpu/cuda-11.8/pytorch/Dockerfile
+++ b/ubuntu/gpu/cuda-11.8/pytorch/Dockerfile
@@ -3,4 +3,5 @@ FROM databricksruntime/gpu-venv:cuda11.8
 # install the pytorch versions
 RUN /databricks/python3/bin/pip install \
     torch==2.0.1 \
-    torchvision==0.15.2 
+    torchvision==0.15.2 \
+    && /databricks/python3/bin/pip cache purge


### PR DESCRIPTION
The pytorch GPU container is quite large, and building off of it is causing timeouts on Databricks.  See #142 .  Purging the pip cache after torch install seems to save about 2 GB on the image size.  Looks like this is done [here](https://github.com/databricks/containers/blob/master/ubuntu/gpu/cuda-11.8/venv/Dockerfile#L57) in the venv image but not done after the torch installs.  This PR fixes that.