### PR TITLE
Install pyccolo in gpu cuda-11.8

### DIFF
--- a/ubuntu/gpu/README.md
+++ b/ubuntu/gpu/README.md
@@ -3,15 +3,14 @@
 **WARNING**: Using conda in DCS images is no longer supported starting Databricks Runtime 9.0. We highly recommend users to extend [`cuda-11.8`](cuda-11.8) examples.
  We no longer support [`cuda-10.1`](cuda-10.1) and [`cuda-11.0`](cuda-11.0) compatibility with latest databricks runtime.
 
-```suggestion
 **WARNING**: DCS images which extends [`venv`](cuda-11.8/venv/) need to be paired with DBR 14.x when creating a
 cluster. In order for REPL to launch successfully, the python packages used in the image HAVE to match with python packges used in the paried DBR version. [`venv`](cuda-11.8/venv/) uses version set from DBR 14.0
 
 
 There are three variations of GPU containers that can be used depending upon the CUDA version you wish to use:
-[`cuda-11.8`](cuda-11.8) contains the layers which install CUDA 11.8
-[`cuda-11.0`](cuda-11.0)(*Deprecated*) contains the layers which install CUDA 11.0
-[`cuda-10.1`](cuda-10.1)(*Deprecated*) contains the layers which install CUDA 10.1
+- [`cuda-11.8`](cuda-11.8) contains the layers which install CUDA 11.8
+- [`cuda-11.0`](cuda-11.0)(*Deprecated*) contains the layers which install CUDA 11.0
+- [`cuda-10.1`](cuda-10.1)(*Deprecated*) contains the layers which install CUDA 10.1
 
  
 Example base layers to build your own container:

--- a/ubuntu/gpu/cuda-11.8/venv/Dockerfile
+++ b/ubuntu/gpu/cuda-11.8/venv/Dockerfile
@@ -35,25 +35,13 @@ RUN /usr/local/bin/pip${python_version} install --no-cache-dir virtualenv==${vir
 # Initialize the default environment that Spark and notebooks will use
 RUN virtualenv --python=python${python_version} --system-site-packages /databricks/python3 --no-download --no-setuptools
 
-
 # These python libraries are used by Databricks notebooks and the Python REPL
 # You do not need to install pyspark - it is injected when the cluster is launched
 # Versions are intended to reflect DBR 14.0: https://docs.databricks.com/release-notes/runtime/releases.html
-RUN /databricks/python3/bin/pip install \
-  six==1.16.0 \
-  jedi==0.18.1 \
-  ipython==8.14.0 \
-  ipython-genutils==0.2.0 \
-  numpy==1.23.5 \
-  pandas==1.5.3 \
-  pyarrow==8.0.0 \
-  matplotlib==3.7.0 \
-  Jinja2==3.1.2\
-  ipykernel==6.25.0 \
-  protobuf==4.23.3 \
-  grpcio==1.48.2 \
-  grpcio-status==1.48.1 \
-  databricks-sdk==0.1.6
+# Certain libraries are added to avoiding breaking 15.4 LTS
+COPY requirements.txt /databricks/.
+
+RUN /databricks/python3/bin/pip install -r /databricks/requirements.txt
 
 
 

--- a/ubuntu/gpu/cuda-11.8/venv/requirements.txt
+++ b/ubuntu/gpu/cuda-11.8/venv/requirements.txt
@@ -1,0 +1,15 @@
+six==1.16.0
+jedi==0.18.1
+ipython==8.14.0
+ipython-genutils==0.2.0
+numpy==1.23.5
+pandas==1.5.3
+pyarrow==8.0.0
+matplotlib==3.7.0
+Jinja2==3.1.2
+ipykernel==6.25.0
+protobuf==4.23.3
+pyccolo==0.0.52
+grpcio==1.48.2
+grpcio-status==1.48.1
+databricks-sdk==0.1.6


### PR DESCRIPTION
The cuda-11.8 image hasn't been updated for a while, and it has Python REPL issue on a cluster with DBR 15.x; meanwhile, DBR 14.3 works. The cluster driver logs showed that the python package `pyccolo` was missing.

Changes:
1. Move requirements for `cuda-11.8/venv` to a dedicated `requirements.txt`
2. Add `pyccolo` to the file

Tested that Python REPL now works:

<img width="350" alt="image" src="https://github.com/user-attachments/assets/82dab146-bfa6-4fff-87a4-e640f6fc08d1">
