### PR TITLE
Upgrade to Python 3.11.11 in DBR 15.4 LTS

### DIFF
--- a/ubuntu/python/Dockerfile
+++ b/ubuntu/python/Dockerfile
@@ -7,6 +7,7 @@ ARG wheel_version="0.38.4"
 ARG virtualenv_version="20.24.2"
 
 # Install python 3.11.11 from deadsnakes, since Ubuntu only packages 3.11.0rc1
+# See release notes: https://docs.databricks.com/aws/en/release-notes/runtime/maintenance-updates#databricks-runtime-154
 RUN mkdir .python3.11/
 WORKDIR .python3.11
 ARG deadsnakes_files="https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa/+files"

--- a/ubuntu/python/Dockerfile
+++ b/ubuntu/python/Dockerfile
@@ -6,9 +6,28 @@ ARG setuptools_version="68.0.0"
 ARG wheel_version="0.38.4"
 ARG virtualenv_version="20.24.2"
 
-# Installs python 3.10 and virtualenv for Spark and Notebooks
+# Install python 3.11.11 from deadsnakes, since Ubuntu only packages 3.11.0rc1
+RUN mkdir .python3.11/
+WORKDIR .python3.11
+ARG deadsnakes_files="https://launchpad.net/~deadsnakes/+archive/ubuntu/ppa/+files"
+RUN curl -LO ${deadsnakes_files}/libpython3.11-minimal_3.11.11-1+jammy1_amd64.deb \
+    && curl -LO ${deadsnakes_files}/libpython3.11-stdlib_3.11.11-1+jammy1_amd64.deb \
+    && curl -LO ${deadsnakes_files}/libpython3.11-dev_3.11.11-1+jammy1_amd64.deb \
+    && curl -LO ${deadsnakes_files}/libpython3.11_3.11.11-1+jammy1_amd64.deb \
+    && curl -LO ${deadsnakes_files}/python3.11-minimal_3.11.11-1+jammy1_amd64.deb \
+    && curl -LO ${deadsnakes_files}/python3.11-dev_3.11.11-1+jammy1_amd64.deb \
+    && curl -LO ${deadsnakes_files}/python3.11_3.11.11-1+jammy1_amd64.deb
+# We expect dpkg to exit non-zero because not all dependencies are installed yet
+# Use DEBIAN_FRONTEND=noninteractive to skip tzdata configuration
+RUN dpkg --force-confdef --force-confold --install ./* || true \
+    && apt-get update \
+    && env DEBIAN_FRONTEND=noninteractive apt-get install --fix-broken -y
+WORKDIR ..
+RUN rm -rf .python3.11/
+
+# Installs python and virtualenv for Spark and Notebooks
 RUN apt-get update \
-  && apt-get install -y curl software-properties-common python${python_version} python${python_version}-dev python${python_version}-distutils \
+  && apt-get install -y curl software-properties-common python${python_version}-distutils \
   && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
   && /usr/bin/python${python_version} get-pip.py pip==${pip_version} setuptools==${setuptools_version} wheel==${wheel_version} \
   && rm get-pip.py

--- a/ubuntu/python/Dockerfile
+++ b/ubuntu/python/Dockerfile
@@ -36,7 +36,7 @@ RUN rm -rf .python3.11/
 # The following are removed after upgrading to 3.11.11:
 # - zlib1g-dev
 # Try to make the dependencies match more closely without breaking anything.
-RUN apt-get install -y zlib1g-dev && apt-get remove -y file libmagic-mgc libmagic1
+RUN apt-get install -y zlib1g-dev && apt-get purge -y file libmagic-mgc libmagic1
 
 # Installs python and virtualenv for Spark and Notebooks
 RUN apt-get update \

--- a/ubuntu/python/Dockerfile
+++ b/ubuntu/python/Dockerfile
@@ -25,6 +25,19 @@ RUN dpkg --force-confdef --force-confold --install ./* || true \
 WORKDIR ..
 RUN rm -rf .python3.11/
 
+# Installing 3.11.11 instead of 3.11.0rc1 pulls in different transitive dependencies.
+# The following are added after upgrading to 3.11.11:
+# - file
+# - libmagic-mgc
+# - libmagic1
+# - mailcap
+# - mime-support
+# - tzdata
+# The following are removed after upgrading to 3.11.11:
+# - zlib1g-dev
+# Try to make the dependencies match more closely without breaking anything.
+RUN apt-get install -y zlib1g-dev && apt-get remove -y file libmagic-mgc libmagic1
+
 # Installs python and virtualenv for Spark and Notebooks
 RUN apt-get update \
   && apt-get install -y curl software-properties-common python${python_version}-distutils \


### PR DESCRIPTION
From the [DBR 15.4 maintenance update notes](https://docs.databricks.com/aws/en/release-notes/runtime/maintenance-updates#databricks-runtime-154):

> To apply critical security patches, the default Python version is updated to Python 3.11.11 from Python 3.11.0rc1. This update might impact some workloads running on Databricks Runtime 15.4 LTS, such as workloads that use Python serialization to store and restore state between executions or workloads that pin to the 3.11.0 Python version.

We should do the same upgrade here for consistency.

I compared the installed system packages to before this change by diffing the output of `dpkg -l`, and found a few necessary differences because Python has different dependencies in the newer version. Diffing the dependencies of the Python packages (got them with `apt depends $(dpkg -l | grep python3.11 | sed -E 's/[^ ]+ +([^ :]+).*/\1/')`) confirms this.

Fixes #201.