### PR TITLE
Remove useradd command which fails because the user already exists

### DIFF
--- a/ubuntu/standard/Dockerfile
+++ b/ubuntu/standard/Dockerfile
@@ -5,6 +5,4 @@ RUN apt-get update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Warning: the created user has root permissions inside the container
 # Warning: you still need to start the ssh process with `sudo service ssh start`
-RUN useradd --create-home --shell /bin/bash --groups sudo ubuntu


### PR DESCRIPTION
Fix the following error, possibly caused by Ubuntu upgrade:

```
The command '/bin/sh -c useradd --create-home --shell /bin/bash --groups sudo ubuntu' returned a non-zero code: 9
```

I ran `lslogins` on the pre-created user and it matches what we have in DBR 16.3, so I think it should have the same behavior.