### PR TITLE
Add `--no-deps` to python-lsp pip install for 16.4

### DIFF
--- a/ubuntu/python/Dockerfile
+++ b/ubuntu/python/Dockerfile
@@ -38,4 +38,4 @@ RUN virtualenv --python=python${python_version} --system-site-packages /databric
 
 COPY python-lsp-requirements.txt /databricks/.
 
-RUN /databricks/python-lsp/bin/pip install -r /databricks/python-lsp-requirements.txt
+RUN /databricks/python-lsp/bin/pip install --no-deps -r /databricks/python-lsp-requirements.txt


### PR DESCRIPTION
The DCS system patch build for 16.4 has been failing for a few weeks because pip dependency resolution fails when installing `python-lsp-requirements.txt`.

This was already fixed for 17.3/master in #231 with the same change. The requirements file pins all dependencies, so `--no-deps` is correct and avoids transitive dependency resolution failures.