### PR TITLE
Constrain `setuptools<82` in `pip build` isolation for 16.4

### DIFF
--- a/ubuntu/python/Dockerfile
+++ b/ubuntu/python/Dockerfile
@@ -27,9 +27,13 @@ RUN virtualenv --python=python${python_version} --system-site-packages /databric
 
 COPY requirements.txt /databricks/.
 
-RUN apt-get install -y libpq-dev build-essential 
+RUN apt-get install -y libpq-dev build-essential
 
-RUN /databricks/python3/bin/pip install --no-deps -r /databricks/requirements.txt
+# Constrain setuptools<82 in pip build isolation environments because
+# setuptools 82+ removed pkg_resources, which pandas 1.5.3's setup.py requires.
+RUN echo 'setuptools<82' > /databricks/build-constraints.txt
+RUN PIP_CONSTRAINT=/databricks/build-constraints.txt \
+    /databricks/python3/bin/pip install --no-deps -r /databricks/requirements.txt
 
 # Specifies where Spark will look for the python process
 ENV PYSPARK_PYTHON=/databricks/python3/bin/python3
@@ -38,4 +42,5 @@ RUN virtualenv --python=python${python_version} --system-site-packages /databric
 
 COPY python-lsp-requirements.txt /databricks/.
 
-RUN /databricks/python-lsp/bin/pip install --no-deps -r /databricks/python-lsp-requirements.txt
+RUN PIP_CONSTRAINT=/databricks/build-constraints.txt \
+    /databricks/python-lsp/bin/pip install --no-deps -r /databricks/python-lsp-requirements.txt


### PR DESCRIPTION
  ## Summary

  The DCS system patch pipeline for `dbr-branch-16.4` has been failing since ~Feb 8
  because `setuptools v82.0.0` (released Feb 8, 2026) removed `pkg_resources` entirely.

  When pip builds `pandas==1.5.3` from source (no cp312 wheel), it creates an isolated
  build environment and installs `setuptools>=51.0.0` (from pandas's `pyproject.toml`),
  which resolves to setuptools 82+. pandas 1.5.3's `setup.py` imports `pkg_resources`,
  causing `ModuleNotFoundError`.

  **Fix:** Set `PIP_CONSTRAINT` to cap `setuptools<82` in pip's build isolation
  environments, keeping `pkg_resources` available for source builds.

  <details>
  <summary>Failing build log (before fix)</summary>

  ```
  Collecting pandas==1.5.3 (from -r /databricks/requirements.txt (line 85))
    Downloading pandas-1.5.3.tar.gz (5.2 MB)
    Installing build dependencies: finished with status 'done'
    Getting requirements to build wheel: finished with status 'error'
    error: subprocess-exited-with-error

    × Getting requirements to build wheel did not run successfully.
    │ exit code: 1
    ╰─> Traceback (most recent call last):
          File "/tmp/pip-build-env-j6aehog5/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 317, in run_setup
            exec(code, locals())
          File "<string>", line 19, in <module>
        ModuleNotFoundError: No module named 'pkg_resources'

  The command '/bin/sh -c /databricks/python3/bin/pip install --no-deps -r /databricks/requirements.txt' returned a non-zero code: 1
  ```

  </details>

  <details>
  <summary>Passing build log (after fix)</summary>

  ```
  Collecting pandas==1.5.3 (from -r /databricks/requirements.txt (line 85))
    Downloading pandas-1.5.3.tar.gz (5.2 MB)
    Installing build dependencies: finished with status 'done'
    Getting requirements to build wheel: finished with status 'done'
  ...
    Building wheel for pandas (pyproject.toml): finished with status 'done'
    Created wheel for pandas: filename=pandas-1.5.3-cp312-cp312-linux_x86_64.whl size=42051187
  ...
  Successfully built kiwisolver pandas psutil psycopg2 ssh-import-id wrapt
  ...
  Successfully tagged test-python-fix:16.4-LTS
  ```

  </details>

  ## Test plan

  - [x] Reproduced the original failure (`docker build` with unmodified Dockerfile)
  - [x] Applied fix and rebuilt → full image builds successfully
  - [ ] Re-trigger the system patch pipeline for `dbr-branch-16.4` DCS after merge