### PR TITLE
Allow customizing python package index

### DIFF
--- a/ubuntu/python/Dockerfile
+++ b/ubuntu/python/Dockerfile
@@ -1,5 +1,6 @@
 FROM databricksruntime/minimal:12.2-LTS
 
+ARG package_index_url="https://pypi.org/simple"
 # These are the versions compatible for DBR 11.x
 ARG python_version="3.9"
 ARG pip_version="21.2.4"
@@ -11,12 +12,12 @@ ARG virtualenv_version="20.8.0"
 RUN apt-get update \
   && apt-get install curl software-properties-common -y python${python_version} python${python_version}-dev python${python_version}-distutils \
   && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-  && /usr/bin/python${python_version} get-pip.py pip==${pip_version} setuptools==${setuptools_version} wheel==${wheel_version} \
+  && /usr/bin/python${python_version} get-pip.py --index-url $package_index_url pip==${pip_version} setuptools==${setuptools_version} wheel==${wheel_version} \
   && rm get-pip.py
 
-RUN /usr/local/bin/pip${python_version} install --no-cache-dir virtualenv==${virtualenv_version} \
+RUN /usr/local/bin/pip${python_version} install --index-url $package_index_url --no-cache-dir virtualenv==${virtualenv_version} \
   && sed -i -r 's/^(PERIODIC_UPDATE_ON_BY_DEFAULT) = True$/\1 = False/' /usr/local/lib/python${python_version}/dist-packages/virtualenv/seed/embed/base_embed.py \
-  && /usr/local/bin/pip${python_version} download pip==${pip_version} --dest \
+  && /usr/local/bin/pip${python_version} download --index-url $package_index_url pip==${pip_version} --dest \
   /usr/local/lib/python${python_version}/dist-packages/virtualenv_support/
 
 # Initialize the default environment that Spark and notebooks will use
@@ -28,7 +29,7 @@ RUN virtualenv --python=python${python_version} --system-site-packages /databric
 
 COPY requirements.txt /databricks/.
 
-RUN /databricks/python3/bin/pip install --no-deps -r /databricks/requirements.txt
+RUN /databricks/python3/bin/pip install --index-url $package_index_url --no-deps -r /databricks/requirements.txt
 
 # Specifies where Spark will look for the python process
 ENV PYSPARK_PYTHON=/databricks/python3/bin/python3
@@ -37,5 +38,5 @@ RUN virtualenv --python=python${python_version} --system-site-packages /databric
 
 COPY python-lsp-requirements.txt /databricks/.
 
-RUN /databricks/python-lsp/bin/pip install -r /databricks/python-lsp-requirements.txt
+RUN /databricks/python-lsp/bin/pip install --index-url $package_index_url -r /databricks/python-lsp-requirements.txt
 


### PR DESCRIPTION
To support using a custom package index, this adds an index URL build argument with pypi as the default value, and sets the index-url param throughout on commands that invoke pip.

Backport of d21c08f to release-12.2-LTS.