### PR TITLE
Allow customizing python package index for GPU and blackice images

### DIFF
--- a/ubuntu/blackice/docker/Dockerfile
+++ b/ubuntu/blackice/docker/Dockerfile
@@ -3,6 +3,7 @@
 ###############################################################################
 # Base Docker image
 ARG BASE_IMAGE=databricksruntime/python:17.3-LTS
+ARG package_index_url="https://pypi.org/simple"
 ARG PYTHON_VERSION="3.12"
 ARG LEGACY_PYTHON_VERSION="3.10"
 ARG TORCH_INDEX_URL="https://download.pytorch.org/whl/torch/"
@@ -43,7 +44,7 @@ ARG STUB_TOOLS="llm-security-scripts gpt-fuzzer"
 FROM ${BASE_IMAGE} AS builder
 
 # Re-expose global ARGs
-ARG PYTHON_VERSION LEGACY_PYTHON_VERSION TORCH_INDEX_URL PYTHON_TOOLS SYSTEM_TOOLS GIT_TOOLS TOOLS_WITH_TORCH_DEP TOOLS_WITH_LEGACY_DEPS NODEJS_TOOLS STUB_TOOLS
+ARG package_index_url PYTHON_VERSION LEGACY_PYTHON_VERSION TORCH_INDEX_URL PYTHON_TOOLS SYSTEM_TOOLS GIT_TOOLS TOOLS_WITH_TORCH_DEP TOOLS_WITH_LEGACY_DEPS NODEJS_TOOLS STUB_TOOLS
 
 # Set essential environment variables
 ENV DEBIAN_FRONTEND=noninteractive
@@ -65,7 +66,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl \
        patch \
     && rm -rf /var/lib/apt/lists/* \
     && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
-    && /usr/local/bin/pip install --no-cache-dir --upgrade --break-system-packages pip uv
+    && /usr/local/bin/pip install --index-url $package_index_url --no-cache-dir --upgrade --break-system-packages pip uv
 
 ENV PATH="/root/.cargo/bin:${PATH}"
 
@@ -98,7 +99,7 @@ RUN for tool in $PYTHON_TOOLS; do \
             SRC_DIR="$VENV_BASE/$TOOL_NAME/source"; \
         fi; \
         mkdir -p $SRC_DIR && \
-        pip download --no-cache-dir --no-deps --no-binary=$TOOL_NAME --dest $SRC_DIR $tool && \
+        pip download --index-url $package_index_url --no-cache-dir --no-deps --no-binary=$TOOL_NAME --dest $SRC_DIR $tool && \
         tar -xvf $SRC_DIR/*.tar.gz -C $SRC_DIR --strip-components=1 && \
         rm $SRC_DIR/*.tar.gz || true; \
     done \
@@ -308,7 +309,7 @@ RUN for tool in $PYTHON_TOOLS; do \
 FROM ${BASE_IMAGE} AS final
 
 # Re-expose global ARGs
-ARG PYTHON_VERSION PYTHON_TOOLS SYSTEM_TOOLS GIT_TOOLS NODEJS_TOOLS CUSTOM_TOOLS STUB_TOOLS
+ARG package_index_url PYTHON_VERSION PYTHON_TOOLS SYSTEM_TOOLS GIT_TOOLS NODEJS_TOOLS CUSTOM_TOOLS STUB_TOOLS
 
 # Set essential environment variables
 ENV DEBIAN_FRONTEND=noninteractive
@@ -334,7 +335,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl nano vim \
     && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
     && apt-get install -y --no-install-recommends figlet nodejs libgl1 libglib2.0-0\
     && rm -rf /var/lib/apt/lists/* \
-    && pip install --no-cache-dir --upgrade --break-system-packages pip uv \
+    && pip install --index-url $package_index_url --no-cache-dir --upgrade --break-system-packages pip uv \
     \
     # Remove conflcting packages from /databricks virtual env
     && for pkg in $(awk -F'[=<>]' '{print $1}' /opt/global_requirements.txt | grep -vE '^#|^$'); do \

--- a/ubuntu/gpu/cuda-11.8/pytorch/Dockerfile
+++ b/ubuntu/gpu/cuda-11.8/pytorch/Dockerfile
@@ -1,7 +1,9 @@
-FROM databricksruntime/gpu-venv:cuda11.8 
+FROM databricksruntime/gpu-venv:cuda11.8
+
+ARG package_index_url="https://pypi.org/simple"
 
 # install the pytorch versions
-RUN /databricks/python3/bin/pip install \
+RUN /databricks/python3/bin/pip install --index-url $package_index_url \
     torch==2.0.1 \
     torchvision==0.15.2 \
     && /databricks/python3/bin/pip cache purge

--- a/ubuntu/gpu/cuda-11.8/tensorflow/Dockerfile
+++ b/ubuntu/gpu/cuda-11.8/tensorflow/Dockerfile
@@ -1,4 +1,6 @@
-FROM databricksruntime/gpu-venv:cuda11.8 
+FROM databricksruntime/gpu-venv:cuda11.8
+
+ARG package_index_url="https://pypi.org/simple"
 
 # Enable NVIDIA repos to install cuda-toolkit required by tensorflow.
 RUN cd /etc/apt/sources.list.d && \
@@ -13,6 +15,6 @@ RUN cd /etc/apt/sources.list.d && \
     mv cuda-ubuntu2204-x86_64.list cuda-ubuntu2204-x86_64.list.disabled
 
 # install the tensorflow versions
-RUN /databricks/python3/bin/pip install \
+RUN /databricks/python3/bin/pip install --index-url $package_index_url \
     tensorflow==2.13.0 \
     tensorboard==2.13.0

--- a/ubuntu/gpu/cuda-11.8/venv/Dockerfile
+++ b/ubuntu/gpu/cuda-11.8/venv/Dockerfile
@@ -1,6 +1,7 @@
 
 FROM databricksruntime/gpu-base:cuda11.8
 
+ARG package_index_url="https://pypi.org/simple"
 ARG python_version="3.10"
 ARG pip_version="22.3.1"
 ARG setuptools_version="65.6.3"
@@ -14,7 +15,7 @@ WORKDIR /databricks
 RUN apt-get update \
   && apt-get install curl software-properties-common -y python${python_version} python${python_version}-dev python${python_version}-distutils \
   && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-  && /usr/bin/python${python_version} get-pip.py pip==${pip_version} setuptools==${setuptools_version} wheel==${wheel_version} \
+  && /usr/bin/python${python_version} get-pip.py --index-url $package_index_url pip==${pip_version} setuptools==${setuptools_version} wheel==${wheel_version} \
   && rm get-pip.py
 
 
@@ -23,9 +24,9 @@ RUN apt-get update \
 # with user cleanup and may allow users to inadvertently update pip to newer versions
 # incompatible with Databricks. Instead, we patch virtualenv to disable periodic updates per
 # https://virtualenv.pypa.io/en/latest/user_guide.html#embed-wheels-for-distributions.
-RUN /usr/local/bin/pip${python_version} install --no-cache-dir virtualenv==${virtualenv_version} \
+RUN /usr/local/bin/pip${python_version} install --index-url $package_index_url --no-cache-dir virtualenv==${virtualenv_version} \
     && sed -i -r 's/^(PERIODIC_UPDATE_ON_BY_DEFAULT) = True$/\1 = False/' /usr/local/lib/python${python_version}/dist-packages/virtualenv/seed/embed/base_embed.py \
-    && /usr/local/bin/pip${python_version} download pip==${pip_version} --dest \
+    && /usr/local/bin/pip${python_version} download --index-url $package_index_url pip==${pip_version} --dest \
     /usr/local/lib/python${python_version}/dist-packages/virtualenv_support/
 
 # Create /databricks/python3 environment.
@@ -41,7 +42,7 @@ RUN virtualenv --python=python${python_version} --system-site-packages /databric
 # Certain libraries are added to avoiding breaking 15.4 LTS
 COPY requirements.txt /databricks/.
 
-RUN /databricks/python3/bin/pip install -r /databricks/requirements.txt
+RUN /databricks/python3/bin/pip install --index-url $package_index_url -r /databricks/requirements.txt
 
 
 
@@ -52,7 +53,7 @@ RUN virtualenv --python=python${python_version} --system-site-packages /databric
 
 COPY python-lsp-requirements.txt /databricks/.
 
-RUN /databricks/python-lsp/bin/pip install -r /databricks/python-lsp-requirements.txt
+RUN /databricks/python-lsp/bin/pip install --index-url $package_index_url -r /databricks/python-lsp-requirements.txt
 
 # Use pip cache purge to cleanup the cache safely
 RUN /databricks/python3/bin/pip cache purge


### PR DESCRIPTION
Extends the package_index_url build ARG to the remaining Dockerfiles that use pip: gpu-venv, gpu pytorch, gpu tensorflow, and blackice.
This is a continuation of d21c08fd1aa806f44fbd64ffb4573c5b0f51675c.