### PR TITLE
Allow customizing python package index for GPU images

### DIFF
--- a/ubuntu/gpu/cuda-11.8/pytorch/Dockerfile
+++ b/ubuntu/gpu/cuda-11.8/pytorch/Dockerfile
@@ -1,6 +1,8 @@
-FROM databricksruntime/gpu-venv:cuda11.8 
+FROM databricksruntime/gpu-venv:cuda11.8
+
+ARG package_index_url="https://pypi.org/simple"
 
 # install the pytorch versions
-RUN /databricks/python3/bin/pip install \
+RUN /databricks/python3/bin/pip install --index-url $package_index_url \
     torch==2.0.1 \
     torchvision==0.15.2 

--- a/ubuntu/gpu/cuda-11.8/tensorflow/Dockerfile
+++ b/ubuntu/gpu/cuda-11.8/tensorflow/Dockerfile
@@ -1,4 +1,6 @@
-FROM databricksruntime/gpu-venv:cuda11.8 
+FROM databricksruntime/gpu-venv:cuda11.8
+
+ARG package_index_url="https://pypi.org/simple"
 
 # Enable NVIDIA repos to install cuda-toolkit required by tensorflow.
 RUN cd /etc/apt/sources.list.d && \
@@ -13,6 +15,6 @@ RUN cd /etc/apt/sources.list.d && \
     mv cuda-ubuntu2204-x86_64.list cuda-ubuntu2204-x86_64.list.disabled
 
 # install the tensorflow versions
-RUN /databricks/python3/bin/pip install \
+RUN /databricks/python3/bin/pip install --index-url $package_index_url \
     tensorflow==2.13.0 \
     tensorboard==2.13.0

--- a/ubuntu/gpu/cuda-11.8/venv/Dockerfile
+++ b/ubuntu/gpu/cuda-11.8/venv/Dockerfile
@@ -1,6 +1,8 @@
 
 FROM databricksruntime/gpu-base:cuda11.8
 
+ARG package_index_url="https://pypi.org/simple"
+
 WORKDIR /databricks
 
 # Install python 3.10 from ubuntu.
@@ -8,7 +10,7 @@ WORKDIR /databricks
 RUN apt-get update \
   && apt-get install curl software-properties-common -y python3.10 python3.10-dev python3.10-distutils \
   && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-  && /usr/bin/python3.10 get-pip.py pip==22.3.1 setuptools==65.6.3 wheel==0.38.4 \
+  && /usr/bin/python3.10 get-pip.py --index-url $package_index_url pip==22.3.1 setuptools==65.6.3 wheel==0.38.4 \
   && rm get-pip.py
 
 
@@ -17,9 +19,9 @@ RUN apt-get update \
 # with user cleanup and may allow users to inadvertently update pip to newer versions
 # incompatible with Databricks. Instead, we patch virtualenv to disable periodic updates per
 # https://virtualenv.pypa.io/en/latest/user_guide.html#embed-wheels-for-distributions.
-RUN /usr/local/bin/pip3.10 install --no-cache-dir virtualenv==20.16.7 \
+RUN /usr/local/bin/pip3.10 install --index-url $package_index_url --no-cache-dir virtualenv==20.16.7 \
     && sed -i -r 's/^(PERIODIC_UPDATE_ON_BY_DEFAULT) = True$/\1 = False/' /usr/local/lib/python3.10/dist-packages/virtualenv/seed/embed/base_embed.py \
-    && /usr/local/bin/pip3.10 download pip==22.3.1 --dest \
+    && /usr/local/bin/pip3.10 download --index-url $package_index_url pip==22.3.1 --dest \
     /usr/local/lib/python3.10/dist-packages/virtualenv_support/
 
 # Create /databricks/python3 environment.
@@ -32,7 +34,7 @@ RUN virtualenv --python=/usr/bin/python3.10 /databricks/python3 --system-site-pa
 # These python libraries are used by Databricks notebooks and the Python REPL
 # You do not need to install pyspark - it is injected when the cluster is launched
 # Versions are intended to reflect DBR 14.0: https://docs.databricks.com/release-notes/runtime/releases.html
-RUN /databricks/python3/bin/pip install \
+RUN /databricks/python3/bin/pip install --index-url $package_index_url \
   six==1.16.0 \
   jedi==0.18.1 \
   ipython==8.14.0 \


### PR DESCRIPTION
Extends the package_index_url build ARG to the remaining Dockerfiles that use pip.
This is a continuation of https://github.com/databricks/containers/commit/d21c08fd1aa806f44fbd64ffb4573c5b0f51675c.