### PR TITLE
Fix pip bootstrap on Python 3.9: use version-pinned get-pip.py

### DIFF
--- a/ubuntu/python/Dockerfile
+++ b/ubuntu/python/Dockerfile
@@ -11,7 +11,7 @@ ARG virtualenv_version="20.8.0"
 # Installs python 3.8 and virtualenv for Spark and Notebooks
 RUN apt-get update \
   && apt-get install curl software-properties-common -y python${python_version} python${python_version}-dev python${python_version}-distutils \
-  && curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+  && curl https://bootstrap.pypa.io/pip/${python_version}/get-pip.py -o get-pip.py \
   && /usr/bin/python${python_version} get-pip.py --index-url $package_index_url pip==${pip_version} setuptools==${setuptools_version} wheel==${wheel_version} \
   && rm get-pip.py
 


### PR DESCRIPTION
## What

`ubuntu/python/Dockerfile` bootstraps pip from the rolling `https://bootstrap.pypa.io/get-pip.py`. pip 26.1 raised that script's minimum to Python 3.10, so on this Python 3.9 release line it now errors:

```
ERROR: This script does not work on Python 3.9. The minimum supported Python version is 3.10. Please use https://bootstrap.pypa.io/pip/3.9/get-pip.py instead.
```

This breaks the `python` image build.

## Change

Use the version-pinned bootstrap URL that pip's own error message recommends:

```
https://bootstrap.pypa.io/pip/${python_version}/get-pip.py
```

(`python_version` is already `3.9` here.) This is the same fix already shipped on `release-10.4-LTS` for Python 3.8 in #222, when pip 25.1 dropped 3.8. The pinned URL is frozen upstream for the 3.9 line, so future pip releases dropping newer Python versions can't break it again.

## Testing

- Verified the pinned URL serves a get-pip with `min_version = (3, 9)` (the rolling script is now `(3, 10)`).
- The `python` image build will be validated via the standard image rebuild.
