### PR TITLE
Pin lm-eval-harness transformers dependency

### DIFF
--- a/ubuntu/blackice/docker/torch_constraints/lm-eval-harness.txt
+++ b/ubuntu/blackice/docker/torch_constraints/lm-eval-harness.txt
@@ -1,1 +1,2 @@
 torch==2.8.0+cpu
+transformers==4.52.4


### PR DESCRIPTION
## Summary
- Pin the BlackIce `lm-eval-harness` venv to `transformers==4.52.4` through its existing torch constraints file.
- Keep the PyRIT and lm-eval versions unchanged.
- Avoid resolving `transformers==5.9.0`, which lacks `AutoModelForVision2Seq` and breaks the lm-eval harness connection test.

## Validation
- Rebuilt BlackIce 17.3 locally with the proxy build args and this constraint.
- Confirmed `/venvs/lm-eval-harness` has `transformers==4.52.4` and `AutoModelForVision2Seq=True`.
- Ran the full BlackIce test suite: `138 passed, 1 warning`. The remaining warning is the existing Logfire/Pydantic plugin warning and is intentionally left unchanged.